### PR TITLE
MusicComponent 추가 및 적용, 일부 Conflict 수정

### DIFF
--- a/OpenRPG/Components/MusicComponent.cpp
+++ b/OpenRPG/Components/MusicComponent.cpp
@@ -1,0 +1,96 @@
+﻿#include "stdafx.h"
+#include "MusicComponent.h"
+
+bool MusicComponent::Loaded() {
+	return !!this->music;
+}
+
+#pragma region Play, Pause, Stop
+MusicComponent* MusicComponent::play() {
+	if (!this->music)
+		return this;
+
+	this->music->play();
+	return this;
+}
+
+MusicComponent* MusicComponent::pause() {
+	if (!this->music)
+		return this;
+
+	this->music->pause();
+	return this;
+}
+
+MusicComponent* MusicComponent::stop() {
+	if (!this->music)
+		return this;
+
+	this->music->stop();
+	return this;
+}
+#pragma endregion
+
+bool MusicComponent::isPlaying() {
+	if (!this->music)
+		return false;
+	return this->music->getStatus() == sf::SoundSource::Status::Playing;
+}
+
+#pragma region Volume
+MusicComponent* MusicComponent::setVolume(float volume) {
+	if (!this->music)
+		return this;
+	this->music->setVolume(volume);
+	return this;
+}
+float MusicComponent::getVolume() {
+	if (!this->music)
+		return -1;
+	return this->music->getVolume();
+}
+#pragma endregion
+
+#pragma region Offset
+MusicComponent* MusicComponent::setOffset(int msec) {
+	if (!this->music)
+		return this;
+
+	this->music->setPlayingOffset(sf::milliseconds(msec));
+	return this;
+}
+int MusicComponent::getOffset() {
+	if (!this->music)
+		return -1;
+
+	return this->music->getPlayingOffset().asMilliseconds();
+}
+#pragma endregion
+
+#pragma region Loop
+MusicComponent* MusicComponent::setLoop(bool loop) {
+	if (!this->music)
+		return this;
+
+	this->music->setLoop(loop);
+	return this;
+}
+bool MusicComponent::getLoop() {
+	if (!this->music)
+		return false;
+	return this->music->getLoop();
+}
+#pragma endregion
+
+MusicComponent::MusicComponent(const std::string& path) {
+	this->reset(path);
+}
+MusicComponent::~MusicComponent() {}
+
+MusicComponent* MusicComponent::reset(const std::string& path) {
+	this->music = g::safe<sf::Music>(new sf::Music());
+	if (!this->music->openFromFile(path))
+		throw "ERROR:MusicComponent::Failed to load file";
+
+	return this;
+}

--- a/OpenRPG/Components/MusicComponent.h
+++ b/OpenRPG/Components/MusicComponent.h
@@ -1,0 +1,29 @@
+﻿#pragma once
+
+class MusicComponent {
+  private:
+	g::safe<sf::Music> music;
+
+  public:
+	bool Loaded();
+	
+	MusicComponent *play();
+	MusicComponent *pause();
+	MusicComponent *stop();
+
+	bool isPlaying();
+
+	MusicComponent *setVolume(float volume);
+	float getVolume();
+
+	MusicComponent *setOffset(int msec);
+	int getOffset();
+
+	MusicComponent *setLoop(bool loop);
+	bool getLoop();
+
+	MusicComponent(const std::string &path);
+	virtual ~MusicComponent();
+
+	MusicComponent *reset(const std::string& path);
+};

--- a/OpenRPG/Managers/SoundManager.cpp
+++ b/OpenRPG/Managers/SoundManager.cpp
@@ -85,25 +85,17 @@ float SoundManager::getVolumeBGM() {
 #pragma endregion
 
 #pragma region BGM, SE
-bool SoundManager::LoadBGM(g::safe<sf::SoundBuffer> buffer) {
+bool SoundManager::LoadBGM(const std::string& path) {
 	if (this->disposed)
 		throw "ERROR::SoundManager::Already Disposed";
 
-	if (!buffer)
-		throw "ERROR:SoundManager::buffer is NULL";
-
-	if (this->BGM) {
-		if (!this->BGM->isSame(buffer))
-			this->BGM->reset(buffer);
-	} else {
-		this->BGM = g::safe<SoundComponent>(new SoundComponent(buffer));
-	}
+	this->BGM = g::safe<MusicComponent>(new MusicComponent(path));
 
 	this->BGM->setVolume(this->volumeBGM);
 	return this->BGM->Loaded();
 }
 
-g::safe<SoundComponent> SoundManager::getBGM() {
+g::safe<MusicComponent> SoundManager::getBGM() {
 	if (this->disposed)
 		throw "ERROR::SoundManager::Already Disposed";
 

--- a/OpenRPG/Managers/SoundManager.h
+++ b/OpenRPG/Managers/SoundManager.h
@@ -2,6 +2,7 @@
 
 #include "Defines/IDisposable.h"
 #include "Components/SoundComponent.h"
+#include "Components/MusicComponent.h"
 
 /// <summary>
 /// <see cref="SoundComponent"/>를 통합 관리하는 클래스입니다.
@@ -38,13 +39,13 @@ class SoundManager : public IDisposable {
 	/// 불러온 정보는 <see cref="getBGM"/>을 통해 불러올 수 있습니다.
 	/// </summary>
 	/// <param name="buffer">BGM으로 불러올 <see cref="sf::SoundBuffer"/>입니다.</param>
-	bool LoadBGM(g::safe<sf::SoundBuffer> buffer);
+	bool LoadBGM(const std::string& path);
 
 	/// <summary>
 	/// 불러온 BGM 정보를 가지는 <see cref="SoundComponent"/> 객체입니다.
 	/// BGM 정보가 없다면 <c>NULL</c>을 반환합니다.
 	/// </summary>
-	g::safe<SoundComponent> getBGM();
+	g::safe<MusicComponent> getBGM();
 
 	/// <summary>
 	/// SE로 재생될 음원을 불러오고 병렬적으로 재생합니다.
@@ -60,7 +61,7 @@ class SoundManager : public IDisposable {
 	static SoundManager* Instance;
 
 	/// <summary>BGM 정보를 담고있는 <see cref="SoundComponent"/> 객체입니다.</summary>
-	g::safe<SoundComponent> BGM;
+	g::safe<MusicComponent> BGM;
 
 	/// <summary>
 	/// 관리되지 않는 SE 정보들을 담고 있는 <see cref="SoundComponent"/> 목록입니다.

--- a/OpenRPG/OpenRPG.vcxproj
+++ b/OpenRPG/OpenRPG.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="Components\AnimationComponent.cpp" />
     <ClCompile Include="Components\HitboxComponent.cpp" />
     <ClCompile Include="Components\MovementComponent.cpp" />
+    <ClCompile Include="Components\MusicComponent.cpp" />
     <ClCompile Include="Components\SoundComponent.cpp" />
     <ClCompile Include="Defines\Animation.cpp" />
     <ClCompile Include="Entities\Entity.cpp" />
@@ -188,6 +189,7 @@
     <ClInclude Include="Components\AnimationComponent.h" />
     <ClInclude Include="Components\HitboxComponent.h" />
     <ClInclude Include="Components\MovementComponent.h" />
+    <ClInclude Include="Components\MusicComponent.h" />
     <ClInclude Include="Components\SoundComponent.h" />
     <ClInclude Include="Defines\Animation.h" />
     <ClInclude Include="Defines\IDisposable.h" />

--- a/OpenRPG/OpenRPG.vcxproj.filters
+++ b/OpenRPG/OpenRPG.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="Game\GraphicsSettings.cpp">
       <Filter>Game</Filter>
     </ClCompile>
+    <ClCompile Include="Components\MusicComponent.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -220,6 +223,9 @@
     </ClInclude>
     <ClInclude Include="Interface.h">
       <Filter>Defines</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\MusicComponent.h">
+      <Filter>Components</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/OpenRPG/States/Editor/EditorState.cpp
+++ b/OpenRPG/States/Editor/EditorState.cpp
@@ -5,10 +5,15 @@
 #include "States/State.h"
 #include "Managers/StateManager.h"
 
-//Initaillizer functions
-void EditorState::initVariables()
-{
-	this->textureRect = sf::IntRect(0, 0, static_cast<int>(this->stateData->gridSize), static_cast<int>(this->stateData->gridSize));
+#include "EditorState.h"
+#include "States/Game/PauseMenu/PauseMenuState.h"
+#include "States/MainMenu/MainMenuState.h"
+
+// Initaillizer functions
+#pragma region Initializers
+void EditorState::initVariables() {
+	auto gridSize = Game::getGridSize();
+	this->textureRect = sf::IntRect(0, 0, static_cast<int>(gridSize), static_cast<int>(gridSize));
 }
 
 void EditorState::initFonts() {
@@ -41,29 +46,20 @@ void EditorState::initButtons() {
 		g::Color("#fff"), g::Color("#fff")));
 }
 
-void EditorState::initText()
-{
-	this->cursorText.setFont(this->font);
+void EditorState::initText() {
+	this->cursorText.setFont(*this->font);
 	this->cursorText.setCharacterSize(15);
 	this->cursorText.setFillColor(sf::Color::Red);
 	this->cursorText.setPosition(sf::Vector2f(this->mousePosView.x, this->mousePosView.y - 30));
 }
 
-void EditorState::initBackground()
-{
-}
+void EditorState::initBackground() {}
+#pragma endregion
 
+void EditorState::initGui() {
+	auto gridSize = Game::getGridSize();
 
-void EditorState::initPauseMenu()
-{
-	this->pmenu = new PauseMenu(*this->window, this->font);
-
-	this->pmenu->addButton("QUIT", 800.f, "Quit", this->tx);
-}
-
-void EditorState::initGui()
-{
-	this->selectorRect.setSize(sf::Vector2f(this->stateData->gridSize, this->stateData->gridSize));
+	this->selectorRect.setSize(sf::Vector2f(gridSize, gridSize));
 	this->selectorRect.setFillColor(sf::Color(255, 255, 255, 150));
 	this->selectorRect.setOutlineThickness(1.f);
 	this->selectorRect.setOutlineColor(sf::Color::Green);
@@ -85,19 +81,6 @@ EditorState::EditorState(State *parent) : State(parent) {
 	this->initButtons();
 	this->initTileMap();
 	this->initGui();
-
-}
-
-EditorState::~EditorState()
-{
-	auto it = this->buttons.begin();
-	for (it = this->buttons.begin(); it != this->buttons.end(); ++it)
-	{
-		delete it->second;
-	}
-
-	delete this->pmenu;
-	delete this->tileMap;
 }
 EditorState::~EditorState() {}
 
@@ -106,72 +89,59 @@ void EditorState::updateInput(const float dt) {
 		this->endState();
 }
 
-void EditorState::updateEditorInput(const float & dt)
-{
+void EditorState::updateEditorInput(const float dt) {
 	//타일 맵 추가하기
-	if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && this->getKeytime())
-	{
+	if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && this->getKeytime()) {
 		this->tileMap->addTile(this->mousePosGrid.x, this->mousePosGrid.y, 0, this->textureRect);
 	}
 
-	if (sf::Mouse::isButtonPressed(sf::Mouse::Right) && this->getKeytime())
-	{
+	if (sf::Mouse::isButtonPressed(sf::Mouse::Right) && this->getKeytime()) {
 		this->tileMap->removeTile(this->mousePosGrid.x, this->mousePosGrid.y, 0);
 	}
 
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::A) && this->getKeytime())
-	{
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::A) && this->getKeytime()) {
 		if (this->textureRect.left < 300)
-		{
 			this->textureRect.left += 100;
-		}
 	}
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::D) && this->getKeytime())
-	{
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::D) && this->getKeytime()) {
 		if (this->textureRect.left > 0)
-		{
 			this->textureRect.left -= 100;
-		}
 	}
 
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::W) && this->getKeytime())
-	{
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::W) && this->getKeytime()) {
 		if (this->textureRect.top < 200)
-		{
 			this->textureRect.top += 100;
-		}
 	}
 
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::S) && this->getKeytime())
-	{
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::S) && this->getKeytime()) {
 		if (this->textureRect.top > 0)
-		{
 			this->textureRect.top -= 100;
-		}
 	}
 }
 
-void EditorState::updateButtons()
-{
+void EditorState::updateButtons() {
 	//모든 버튼들의 상태를 기능에맞게 업데이트해줌
 	for (auto &it : this->buttons) {
 		it.second->update(this->mousePosView);
 	}
 
 	if (this->buttons["EXIT_STATE"]->isPressed()) {
-		StateManager::getInstance()->GoTo(SafeState(MainMenuState));
+		StateManager::getInstance()->Push(SafeState(MainMenuState));
 		return;
 	}
 }
 
-void EditorState::updateGui()
-{
+void EditorState::updateGui() {
+	auto gridSize = Game::getGridSize();
+
 	this->selectorRect.setTextureRect(this->textureRect);
-	this->selectorRect.setPosition(this->mousePosGrid.x * this->stateData->gridSize, this->mousePosGrid.y* this->stateData->gridSize);
+	this->selectorRect.setPosition(
+		this->mousePosGrid.x * gridSize, this->mousePosGrid.y * gridSize);
 
 	this->cursorText.setPosition(sf::Vector2f(this->mousePosView.x, this->mousePosView.y - 30));
 	std::stringstream ss;
-	ss << this->mousePosView.x << " " << this->mousePosView.y << '\n' << this->textureRect.left << " " << this->textureRect.top;
+	ss << this->mousePosView.x << " " << this->mousePosView.y << '\n'
+	   << this->textureRect.left << " " << this->textureRect.top;
 	cursorText.setString(ss.str());
 }
 
@@ -184,28 +154,16 @@ void EditorState::update() {
 	this->updateKeytime(dt);
 	this->updateInput(dt);
 
-	if (!this->paused)
-	{
-		this->updateButtons();
-		this->updateGui();
-		this->updateEditorInput(dt);
-	}
-	else
-	{
-		this->pmenu->update(this->mousePosView);
-		this->updatePauseMenuButtons();
-	}
+	this->updateButtons();
 }
 
 void EditorState::renderGui(sf::RenderTarget *target) {
 	target->draw(this->selectorRect);
+	target->draw(this->cursorText);
 }
 
-void EditorState::renderGui(sf::RenderTarget & target)
-{
-	target.draw(this->selectorRect);
-	target.draw(this->cursorText);
-}
+void EditorState::render(sf::RenderTarget *target) {
+	State::render(target);
 
 	if (!target)
 		target = Game::getWindow().get();
@@ -213,10 +171,9 @@ void EditorState::renderGui(sf::RenderTarget & target)
 
 	this->renderButtons(target);
 	this->renderGui(target);
+}
 
-	if (this->paused) {
-		this->pmenu->render(*target);
-	}
-
-
+void EditorState::renderButtons(sf::RenderTarget *target) {
+	for (auto &it : this->buttons)
+		it.second->render(target);
 }

--- a/OpenRPG/States/Editor/EditorState.h
+++ b/OpenRPG/States/Editor/EditorState.h
@@ -6,13 +6,11 @@
 
 class EditorState : public State {
   private:
-	//변수
-	sf::Font font;
-	sf::Text cursorText;
-	std::map<std::string, gui::Button*> buttons;
-	sf::Texture tx;
-	PauseMenu* pmenu;
+	g::safe<sf::Font> font;
+	g::safe<sf::Texture> tx;
+	g::safemap<gui::Button> buttons;
 
+	sf::Text cursorText;
 	g::safe<TileMap> tileMap;
 
 	sf::IntRect textureRect;
@@ -30,8 +28,8 @@ class EditorState : public State {
 
   public:
 	const StateFlow flow() {
-		// 흐를 수 없음
-		return StateFlow::FLOW_NONE;
+		// 렌더링만 가능
+		return StateFlow::FLOW_RENDER;
 	}
 
 	EditorState(State* parent);
@@ -39,8 +37,9 @@ class EditorState : public State {
 	virtual void onActivated() {}
 	virtual void onDeactivated() {}
 
-	void updateInput(const float& dt);
-	void updateEditorInput(const float& dt);
+	//업데이트함수
+	void updateInput(const float dt);
+	void updateEditorInput(const float dt);
 	void updateButtons();
 	void updateGui();
 	void update();

--- a/OpenRPG/States/MainMenu/MainMenuState.cpp
+++ b/OpenRPG/States/MainMenu/MainMenuState.cpp
@@ -2,7 +2,6 @@
 
 #include "Game/Game.h"
 #include "GUI/Gui.h"
-#include "Components/SoundComponent.h"
 #include "States/State.h"
 #include "States/MainMenu/MainMenuState.h"
 #include "States/Game/GameState.h"
@@ -82,9 +81,10 @@ void MainMenuState::initButtons() {
 }
 
 void MainMenuState::initSounds() {
-	auto sound = this->res.Sounds["BACKGROUND_MUSIC"] = g::safe<sf::SoundBuffer>(new sf::SoundBuffer());
-	if (!sound->loadFromFile("Resources/sound/bgm.wav"))
-		throw "ERROR::GAME_STATE::COULD_NOT_LOAD_BGM";
+	// 메인 화면이 생성될 때 BGM 재생
+	auto sm = SoundManager::getInstance();
+	sm->LoadBGM("Resources/sound/bgm.wav");
+	sm->getBGM()->setLoop(true)->play();
 }
 #pragma endregion
 
@@ -95,11 +95,6 @@ MainMenuState::MainMenuState() : State() {
 	this->initKeybinds();
 	this->initButtons();
 	this->initSounds();
-
-	// 메인 화면이 생성될 때 BGM 재생
-	auto sm = SoundManager::getInstance();
-	sm->LoadBGM(this->res.Sounds["BACKGROUND_MUSIC"]);
-	sm->getBGM()->setLoop(true)->play();
 }
 
 MainMenuState::~MainMenuState() {

--- a/OpenRPG/States/State.cpp
+++ b/OpenRPG/States/State.cpp
@@ -7,12 +7,11 @@
 
 State::State(State* parent) {
 	this->parent = parent;
-	
+
 	this->keyTime = 0.f;
 	this->keyTimeMax = 0.1f;
 }
-State::~State() {
-}
+State::~State() {}
 
 const bool State::getKeytime() {
 	if (this->keyTime >= this->keyTimeMax) {
@@ -24,13 +23,7 @@ const bool State::getKeytime() {
 
 //현재 스테이지를 끝내는 것이므로 pop으로 수정.
 void State::endState() {
-	StateManager::getInstance()->Pop();
-}
-void State::pauseState() {
-	this->paused = true;
-}
-void State::unpauseState() {
-	this->paused = false;
+	StateManager::getInstance()->PopUntil(this);
 }
 
 void State::updateKeytime(const float dt) {
@@ -40,14 +33,14 @@ void State::updateKeytime(const float dt) {
 
 void State::updateMousePositions() {
 	auto window = Game::getWindow();
+	auto gridSize = Game::getGridSize();
+
 	this->mousePosScreen = sf::Mouse::getPosition();
-	this->mousePosWindow = sf::Mouse::getPosition(*this->window);
-	this->mousePosView = this->window->mapPixelToCoords(sf::Mouse::getPosition(*this->window));
-	this->mousePosGrid =
-		sf::Vector2u(
-			static_cast<unsigned>(this->mousePosView.x)/static_cast<unsigned>(this->gridSize),
-			static_cast<unsigned>(this->mousePosView.y/ static_cast<unsigned>(this->gridSize))
-		);
+	this->mousePosWindow = sf::Mouse::getPosition(*window);
+	this->mousePosView = window->mapPixelToCoords(sf::Mouse::getPosition(*window));
+	this->mousePosGrid = sf::Vector2u(
+		static_cast<unsigned>(this->mousePosView.x) / static_cast<unsigned>(gridSize),
+		static_cast<unsigned>(this->mousePosView.y / static_cast<unsigned>(gridSize)));
 }
 
 void State::update() {

--- a/OpenRPG/States/State.h
+++ b/OpenRPG/States/State.h
@@ -50,7 +50,6 @@ class State {
 	g::map<int> keybinds;
 	float keyTime;
 	float keyTimeMax;
-	float gridSize;
 
 	sf::Vector2i mousePosScreen;
 	sf::Vector2i mousePosWindow;


### PR DESCRIPTION
내부적으로 스트리밍 방식으로 음원을 재생하는 `sf::Music`을 이용한 `MusicComponent`를 추가했습니다.

이에 더해서 기존 `exp/StateFlow`와 머지하면서 발생한 Conflict 일부를 수정했습니다.

`SoundManager`의 `BGM`은 `MusicComponent`로 변경되었습니다.

### 원리 및 세부 설명
기존의 `SoundComponent`는 음원의 모든 내용을 불러와서 메모리에 적재하여 재생합니다.

그렇기에 배경음악과 같은 용량이 큰 음원을 불러올 때에는 많은 처리량 때문에 스레드가 멈추고 프로그램의 메모리 사용량이 급증하게 됩니다.

따라서 음원의 일부분만을 불러와서 사운드 버퍼에 순차적으로 적재해서 재생하는 방식으로 구현되어야 했습니다.

SFML의 `sf::Music` 클래스는 이를 구현해둔 클래스로, 이를 이용한 컴포넌트를 제작했습니다.
