### PR TITLE
🎨 백 텍스쳐를 사용한 render 체계

### DIFF
--- a/OpenRPG/Entities/Player.cpp
+++ b/OpenRPG/Entities/Player.cpp
@@ -77,7 +77,7 @@ void Player::updateAttack() {
 	}
 }
 
-void Player::updateAnimation(const float& dt) {
+void Player::updateAnimation(const float dt) {
 	if (this->attacking) {
 		//바라보는 방향체크
 		if (this->sprite->getScale().x > 0.f) //왼쪽
@@ -130,7 +130,7 @@ void Player::updateAnimation(const float& dt) {
 	}
 }
 
-void Player::update(const float& dt) {
+void Player::update(const float dt) {
 	this->movementComponent->update(dt);
 
 	this->updateAttack();

--- a/OpenRPG/Entities/Player.h
+++ b/OpenRPG/Entities/Player.h
@@ -17,6 +17,6 @@ class Player : public Entity {
 
 	// Functions
 	void updateAttack();
-	void updateAnimation(const float& dt);
-	virtual void update(const float& dt);
+	void updateAnimation(const float dt);
+	virtual void update(const float dt);
 };

--- a/OpenRPG/Game/Game.cpp
+++ b/OpenRPG/Game/Game.cpp
@@ -44,6 +44,7 @@ void Game::Dispose() {
 #pragma region Initializers
 void Game::initVariables() {
 	this->gridSize = 50.f;
+}
 
 void Game::initWindow() {
 	if (this->gfxSettings.fullscreen)

--- a/OpenRPG/Managers/StateManager.cpp
+++ b/OpenRPG/Managers/StateManager.cpp
@@ -1,4 +1,6 @@
 ﻿#include "stdafx.h"
+
+#include "Game/Game.h"
 #include "StateManager.h"
 
 #pragma region getInstance, Constructor, Finalizer, Dispose
@@ -135,6 +137,11 @@ StateManager* StateManager::Update() {
 	if (render)
 		renderIdx = 0;
 
+	// 렌더 타깃 텍스쳐를 생성
+	auto resolution = Game::getGraphicsSettings()->resolution;
+	sf::RenderTexture renderTarget;
+	renderTarget.create(resolution.width, resolution.height);
+
 	// 갱신하거나 그릴 수 있는 장면들 중 가장 아래에 있는 장면부터 시작
 	auto startIdx = std::min(updateIdx, renderIdx);
 	for (g::safevector<State>::size_type i = startIdx; i < stackSize; i++) {
@@ -143,9 +150,17 @@ StateManager* StateManager::Update() {
 		if (i >= updateIdx)
 			item->update();
 
-		if (i >= renderIdx)
-			item->render();
+		if (i >= renderIdx) {
+			item->render(&renderTarget);
+
+			// 내부 실제 텍스쳐에 반영?
+			renderTarget.display();
+		}
 	}
+
+	// 완성된(모든 장면의 내용을 담은) 텍스쳐를 실제 화면에 그리기
+	sf::Sprite renderTargetSprite(renderTarget.getTexture());
+	Game::getWindow()->draw(renderTargetSprite);
 
 	return this;
 }

--- a/OpenRPG/Maps/TileMap.cpp
+++ b/OpenRPG/Maps/TileMap.cpp
@@ -1,67 +1,52 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "TileMap.h"
 
-TileMap::TileMap(float gridSize, unsigned width, unsigned height)
-{
+TileMap::TileMap(float gridSize, unsigned width, unsigned height) {
 	this->gridSizeF = gridSize;
 	this->gridSizeU = static_cast<unsigned>(this->gridSizeF);
 	this->maxSize.x = width;
 	this->maxSize.y = height;
 	this->layers = 1;
 
-	this->map.resize(this->maxSize.x, std::vector<std::vector<Tile*>>());
-	for (size_t x = 0; x < maxSize.x; x++)
-	{
-		for (size_t y = 0; y < maxSize.y; y++)
-		{
-			this->map[x].push_back(std::vector<Tile*>());
-			for (size_t z = 0; z < this->layers; z++)
-			{
-				this->map[x][y].resize(this->layers,NULL);
+	this->map.resize(this->maxSize.x, std::vector<std::vector<Tile *>>());
+	for (size_t x = 0; x < maxSize.x; x++) {
+		for (size_t y = 0; y < maxSize.y; y++) {
+			this->map[x].push_back(std::vector<Tile *>());
+			for (size_t z = 0; z < this->layers; z++) {
+				this->map[x][y].resize(this->layers, NULL);
 			}
 		}
 	}
 
-	if (!this->tileSheet.loadFromFile("Resources/map/sheet.png"))
+	this->tileSheet = g::safe<sf::Texture>(new sf::Texture());
+	if (!this->tileSheet->loadFromFile("Resources/map/sheet.png"))
 		throw "TileMap load failed";
 }
 
-TileMap::~TileMap() {}
-
-TileMap::~TileMap()
-{
+TileMap::~TileMap() {
 	this->map.resize(this->maxSize.x);
-	for (size_t x = 0; x < maxSize.x; x++)
-	{
-		for (size_t y = 0; y < maxSize.y; y++)
-		{
-			for (size_t z = 0; z < this->layers; z++)
-			{
+	for (size_t x = 0; x < maxSize.x; x++) {
+		for (size_t y = 0; y < maxSize.y; y++) {
+			for (size_t z = 0; z < this->layers; z++) {
 				delete this->map[x][y][z];
 			}
+			this->map[x][y].clear();
 		}
+		this->map[x].clear();
 	}
+	this->map.clear();
 }
 
-const sf::Texture * TileMap::getTileSheet() const
-{
-
-	return &this->tileSheet;
+const g::safe<sf::Texture> TileMap::getTileSheet() const {
+	return this->tileSheet;
 }
 
-void TileMap::update()
-{
+void TileMap::update() {}
 
-}
-
-void TileMap::render(sf::RenderTarget & target)
-{
-	for (auto &x : this->map)
-	{
-		for (auto &y : x)
-		{
-			for (auto *z : y)
-			{
+void TileMap::render(sf::RenderTarget *target) {
+	for (auto &x : this->map) {
+		for (auto &y : x) {
+			for (auto *z : y) {
 				if (z != nullptr)
 					z->render(target);
 			}
@@ -69,28 +54,18 @@ void TileMap::render(sf::RenderTarget & target)
 	}
 }
 
-void TileMap::addTile(const unsigned x, const unsigned y, const unsigned z, const sf::IntRect& texture_rect)
-{
-	if (x < this->maxSize.x && x >= 0 &&
-		y < this->maxSize.y && y >= 0 &&
-		z < this->layers && z >= 0)
-	{
-		if (this->map[x][y][z] == NULL) //비어있을때만 타일을 삽입한다.
-		{
+void TileMap::addTile(const unsigned x, const unsigned y, const unsigned z, const sf::IntRect texture_rect) {
+	if (x < this->maxSize.x && x >= 0 && y < this->maxSize.y && y >= 0 && z < this->layers && z >= 0) {
+		if (this->map[x][y][z] == NULL) { // 비어있을때만 타일을 삽입한다.
 			this->map[x][y][z] = new Tile(x * this->gridSizeF, y * this->gridSizeF, this->gridSizeF, this->tileSheet, texture_rect);
 			std::cout << "DEBUG: 타일이 추가되었습니다!" << std::endl;
 		}
 	}
 }
 
-void TileMap::removeTile(const unsigned x, const unsigned y, const unsigned z)
-{
-	if (x < this->maxSize.x && x >= 0 &&
-		y < this->maxSize.y && y >= 0 &&
-		z < this->layers && z >= 0)
-	{
-		if (this->map[x][y][z] != NULL) //비어있을때만 타일을 삽입한다.
-		{
+void TileMap::removeTile(const unsigned x, const unsigned y, const unsigned z) {
+	if (x < this->maxSize.x && x >= 0 && y < this->maxSize.y && y >= 0 && z < this->layers && z >= 0) {
+		if (this->map[x][y][z] != NULL) { // 비어있을때만 타일을 삽입한다.
 			delete this->map[x][y][z];
 			this->map[x][y][z] = NULL;
 			std::cout << "DEBUG: 타일이 삭제되었습니다!" << std::endl;

--- a/OpenRPG/Maps/TileMap.h
+++ b/OpenRPG/Maps/TileMap.h
@@ -6,22 +6,24 @@ class TileMap {
   private:
 	float gridSizeF;
 	unsigned gridSizeU;
+
 	sf::Vector2u maxSize;
 	unsigned layers;
+
 	std::vector<std::vector<std::vector<Tile*>>> map;
-	sf::Texture tileSheet;
+	g::safe<sf::Texture> tileSheet;
 
 public:
 	TileMap(float gridSize, unsigned width, unsigned height);
 	virtual ~TileMap();
 	
 	//접근자
-	const sf::Texture* getTileSheet() const;
+	const g::safe<sf::Texture> getTileSheet() const;
 
 	//함수
 	void update();
 	void render(sf::RenderTarget* target);
 
-	void addTile(const unsigned x, const unsigned y, const unsigned z, const sf::IntRect& texture_rect);
+	void addTile(const unsigned x, const unsigned y, const unsigned z, const sf::IntRect texture_rect);
 	void removeTile(const unsigned x, const unsigned y, const unsigned z);
 };

--- a/OpenRPG/States/Editor/EditorState.cpp
+++ b/OpenRPG/States/Editor/EditorState.cpp
@@ -88,7 +88,6 @@ void EditorState::updateInput(const float dt) {
 	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key(this->keybinds.at("CLOSE"))))
 		this->endState();
 }
-
 void EditorState::updateEditorInput(const float dt) {
 	//타일 맵 추가하기
 	if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && this->getKeytime()) {
@@ -118,7 +117,6 @@ void EditorState::updateEditorInput(const float dt) {
 			this->textureRect.top -= 100;
 	}
 }
-
 void EditorState::updateButtons() {
 	//모든 버튼들의 상태를 기능에맞게 업데이트해줌
 	for (auto &it : this->buttons) {
@@ -130,7 +128,6 @@ void EditorState::updateButtons() {
 		return;
 	}
 }
-
 void EditorState::updateGui() {
 	auto gridSize = Game::getGridSize();
 
@@ -144,7 +141,6 @@ void EditorState::updateGui() {
 	   << this->textureRect.left << " " << this->textureRect.top;
 	cursorText.setString(ss.str());
 }
-
 void EditorState::update() {
 	State::update();
 
@@ -157,23 +153,19 @@ void EditorState::update() {
 	this->updateButtons();
 }
 
-void EditorState::renderGui(sf::RenderTarget *target) {
+void EditorState::renderGui(sf::RenderTexture *target) {
 	target->draw(this->selectorRect);
 	target->draw(this->cursorText);
 }
-
-void EditorState::render(sf::RenderTarget *target) {
+void EditorState::renderButtons(sf::RenderTexture *target) {
+	for (auto &it : this->buttons)
+		it.second->render(target);
+}
+void EditorState::render(sf::RenderTexture *target) {
 	State::render(target);
 
-	if (!target)
-		target = Game::getWindow().get();
 	this->tileMap->render(target);
 
 	this->renderButtons(target);
 	this->renderGui(target);
-}
-
-void EditorState::renderButtons(sf::RenderTarget *target) {
-	for (auto &it : this->buttons)
-		it.second->render(target);
 }

--- a/OpenRPG/States/Editor/EditorState.cpp
+++ b/OpenRPG/States/Editor/EditorState.cpp
@@ -64,7 +64,7 @@ void EditorState::initGui() {
 	this->selectorRect.setOutlineThickness(1.f);
 	this->selectorRect.setOutlineColor(sf::Color::Green);
 
-	this->selectorRect.setTexture(this->tileMap->getTileSheet());
+	this->selectorRect.setTexture(this->tileMap->getTileSheet().get());
 	this->selectorRect.setTextureRect(this->textureRect);
 }
 
@@ -126,7 +126,7 @@ void EditorState::updateButtons() {
 	}
 
 	if (this->buttons["EXIT_STATE"]->isPressed()) {
-		StateManager::getInstance()->Push(SafeState(MainMenuState));
+		StateManager::getInstance()->GoTo(SafeState(MainMenuState));
 		return;
 	}
 }

--- a/OpenRPG/States/Editor/EditorState.h
+++ b/OpenRPG/States/Editor/EditorState.h
@@ -28,8 +28,8 @@ class EditorState : public State {
 
   public:
 	const StateFlow flow() {
-		// 렌더링만 가능
-		return StateFlow::FLOW_RENDER;
+		// 흐를 수 없음
+		return StateFlow::FLOW_NONE; 
 	}
 
 	EditorState(State* parent);

--- a/OpenRPG/States/Editor/EditorState.h
+++ b/OpenRPG/States/Editor/EditorState.h
@@ -45,7 +45,7 @@ class EditorState : public State {
 	void update();
 
 	//랜더함수
-	void renderButtons(sf::RenderTarget* target);
-	void renderGui(sf::RenderTarget* target);
-	void render(sf::RenderTarget* target = NULL);
+	void renderButtons(sf::RenderTexture* target);
+	void renderGui(sf::RenderTexture* target);
+	void render(sf::RenderTexture* target);
 };

--- a/OpenRPG/States/Game/GameState.cpp
+++ b/OpenRPG/States/Game/GameState.cpp
@@ -79,7 +79,6 @@ void GameState::updateInput(const float dt) {
 // Update functions
 
 void GameState::updatePauseButtons() {}
-
 void GameState::updatePlayerInput(const float dt) {
 	if (Game::getFocused()) {
 		//사용자 입력 업데이트
@@ -93,7 +92,6 @@ void GameState::updatePlayerInput(const float dt) {
 			this->player->move(0.f, 2.f, dt);
 	}
 }
-
 void GameState::update() {
 	State::update();
 	auto dt = Game::getInstance()->deltaTime();
@@ -104,11 +102,8 @@ void GameState::update() {
 	}
 }
 
-void GameState::render(sf::RenderTarget* target) {
+void GameState::render(sf::RenderTexture* target) {
 	State::render(target);
-
-	if (!target)
-		target = Game::getWindow().get();
 
 	this->tileMap->render(target);
 	this->player->render(target);

--- a/OpenRPG/States/Game/GameState.h
+++ b/OpenRPG/States/Game/GameState.h
@@ -35,10 +35,10 @@ class GameState : public State {
 	void onDeactivated() {}
 
 	//함수
+	void updatePauseButtons();
 	void updatePlayerInput(const float dt);
 	void updateInput(const float dt);
-	void updatePauseButtons();
 	void update();
 
-	void render(sf::RenderTarget* target = NULL);
+	void render(sf::RenderTexture* target);
 };

--- a/OpenRPG/States/Game/PauseMenu/PauseMenuState.cpp
+++ b/OpenRPG/States/Game/PauseMenu/PauseMenuState.cpp
@@ -72,6 +72,10 @@ PauseMenuState::PauseMenuState() : State() {
 }
 PauseMenuState::~PauseMenuState() {}
 
+void PauseMenuState::updateInput(const float dt) {
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key(this->keybinds.at("CLOSE"))))
+		this->endState();
+}
 void PauseMenuState::update() {
 	State::update();
 
@@ -87,16 +91,8 @@ void PauseMenuState::update() {
 	}
 }
 
-void PauseMenuState::updateInput(const float dt) {
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key(this->keybinds.at("CLOSE"))))
-		this->endState();
-}
-
-void PauseMenuState::render(sf::RenderTarget* target) {
+void PauseMenuState::render(sf::RenderTexture* target) {
 	State::render(target);
-
-	if (!target)
-		target = Game::getWindow().get();
 
 	target->draw(background);
 	target->draw(container);

--- a/OpenRPG/States/Game/PauseMenu/PauseMenuState.h
+++ b/OpenRPG/States/Game/PauseMenu/PauseMenuState.h
@@ -37,7 +37,8 @@ class PauseMenuState : public State {
 	void updatePlayerInput(const float dt) {}
 	void updateInput(const float dt);
 	void update();
-	void render(sf::RenderTarget* target = NULL);
+
+	void render(sf::RenderTexture* target);
 
 	// State 이벤트
 	void onActivated() {}

--- a/OpenRPG/States/MainMenu/MainMenuState.cpp
+++ b/OpenRPG/States/MainMenu/MainMenuState.cpp
@@ -96,7 +96,6 @@ MainMenuState::MainMenuState() : State() {
 	this->initButtons();
 	this->initSounds();
 }
-
 MainMenuState::~MainMenuState() {
 	// 메인 화면이 제거될 때 BGM 중지
 	SoundManager::getInstance()->getBGM()->stop();
@@ -106,7 +105,6 @@ void MainMenuState::updateInput(const float dt) {
 	if (sf::Keyboard::isKeyPressed(sf::Keyboard::G))
 		this->background.setFillColor(sf::Color::Cyan);
 }
-
 void MainMenuState::updateButtons() {
 	//모든 버튼들의 상태를 기능에맞게 업데이트해줌
 	for (auto& it : this->buttons)
@@ -136,7 +134,6 @@ void MainMenuState::updateButtons() {
 		return;
 	}
 }
-
 void MainMenuState::update() {
 	State::update();
 
@@ -148,11 +145,12 @@ void MainMenuState::update() {
 	this->updateButtons();
 }
 
-void MainMenuState::render(sf::RenderTarget* target) {
+void MainMenuState::renderButtons(sf::RenderTexture* target) {
+	for (auto& it : this->buttons)
+		it.second->render(target);
+}
+void MainMenuState::render(sf::RenderTexture* target) {
 	State::render(target);
-
-	if (!target)
-		target = Game::getWindow().get();
 
 	target->draw(this->background);
 	this->renderButtons(target);
@@ -168,9 +166,4 @@ void MainMenuState::render(sf::RenderTarget* target) {
 	mouseText.setString(ss.str());
 
 	target->draw(mouseText);
-}
-
-void MainMenuState::renderButtons(sf::RenderTarget* target) {
-	for (auto& it : this->buttons)
-		it.second->render(target);
 }

--- a/OpenRPG/States/MainMenu/MainMenuState.h
+++ b/OpenRPG/States/MainMenu/MainMenuState.h
@@ -35,8 +35,8 @@ class MainMenuState : public State {
 	//함수
 	void updateInput(const float dt);
 	void updateButtons();
-	void renderButtons(sf::RenderTarget* target);
-
 	void update();
-	void render(sf::RenderTarget* target = NULL);
+
+	void renderButtons(sf::RenderTexture* target);
+	void render(sf::RenderTexture* target);
 };

--- a/OpenRPG/States/Settings/SettingsState.cpp
+++ b/OpenRPG/States/Settings/SettingsState.cpp
@@ -77,7 +77,6 @@ void SettingsState::updateInput(const float dt) {
 		return;
 	}
 }
-
 void SettingsState::updateGui() {
 	auto dt = Game::getInstance()->deltaTime();
 
@@ -107,7 +106,6 @@ void SettingsState::updateGui() {
 		it.second->update(this->mousePosView, dt);
 	}
 }
-
 void SettingsState::update() {
 	State::update();
 
@@ -119,19 +117,15 @@ void SettingsState::update() {
 	this->updateGui();
 }
 
-void SettingsState::renderGui(sf::RenderTarget *target) {
+void SettingsState::renderGui(sf::RenderTexture *target) {
 	for (auto &it : this->buttons)
 		it.second->render(target);
 
 	for (auto &it : this->dropDownLists)
 		it.second->render(target);
 }
-
-void SettingsState::render(sf::RenderTarget *target) {
+void SettingsState::render(sf::RenderTexture *target) {
 	State::render(target);
-
-	if (!target)
-		target = Game::getWindow().get();
 
 	this->renderGui(target);
 	target->draw(this->optionsText);

--- a/OpenRPG/States/Settings/SettingsState.cpp
+++ b/OpenRPG/States/Settings/SettingsState.cpp
@@ -35,21 +35,19 @@ void SettingsState::initGui() {
 		throw "btn";
 
 	this->buttons["BACK"] = g::safe<gui::Button>(new gui::Button(
-		100, 800, 250, 200, this->tx, this->font, L"뒤로가기", 50, g::Color("#000"),
-		g::Color("#969696fa"), g::Color("#14141432"), g::Color("#fff"), g::Color("#fff"),
-		g::Color("#fff")));
+		100, 800, 250, 200, this->tx, this->font, L"뒤로가기", 50, g::Color("#000"), g::Color("#969696fa"), g::Color("#14141432"),
+		g::Color("#fff"), g::Color("#fff"), g::Color("#fff")));
 
 	this->buttons["APPLY"] = g::safe<gui::Button>(new gui::Button(
-		400, 800, 250, 200, this->tx, this->font, L"적용", 50, g::Color("#000"),
-		g::Color("#969696fa"), g::Color("#14141432"), g::Color("#fff"), g::Color("#fff"),
-		g::Color("#fff")));
+		400, 800, 250, 200, this->tx, this->font, L"적용", 50, g::Color("#000"), g::Color("#969696fa"), g::Color("#14141432"),
+		g::Color("#fff"), g::Color("#fff"), g::Color("#fff")));
 
 	std::vector<std::wstring> modes_str;
 	for (auto &i : this->modes)
 		modes_str.push_back(std::to_wstring(i.width) + L'x' + std::to_wstring(i.height));
 
-	this->dropDownLists["RESOLUTION"] = g::safe<gui::DropDownList>(
-		new gui::DropDownList(400, 100, 200, 50, font, modes_str.data(), modes_str.size()));
+	this->dropDownLists["RESOLUTION"] =
+		g::safe<gui::DropDownList>(new gui::DropDownList(400, 100, 200, 50, font, modes_str.data(), modes_str.size()));
 }
 
 void SettingsState::initText() {
@@ -97,8 +95,7 @@ void SettingsState::updateGui() {
 	if (this->buttons["APPLY"]->isPressed()) {
 		//삭제예정 테스트용 설정이날아가기때문에 프레임이 솓구칩니다.
 		auto gfxSettings = Game::getGraphicsSettings();
-		gfxSettings->resolution =
-			this->modes[this->dropDownLists["RESOLUTION"]->getActiveElementId()];
+		gfxSettings->resolution = this->modes[this->dropDownLists["RESOLUTION"]->getActiveElementId()];
 
 		auto window = Game::getWindow();
 		window->create(gfxSettings->resolution, gfxSettings->title, sf::Style::Default);
@@ -123,13 +120,11 @@ void SettingsState::update() {
 }
 
 void SettingsState::renderGui(sf::RenderTarget *target) {
-	for (auto &it : this->buttons) {
+	for (auto &it : this->buttons)
 		it.second->render(target);
-	}
 
-	for (auto &it : this->dropDownLists) {
+	for (auto &it : this->dropDownLists)
 		it.second->render(target);
-	}
 }
 
 void SettingsState::render(sf::RenderTarget *target) {

--- a/OpenRPG/States/Settings/SettingsState.h
+++ b/OpenRPG/States/Settings/SettingsState.h
@@ -45,8 +45,8 @@ class SettingsState : public State {
 	void update();
 
 	//랜더함수
-	void renderGui(sf::RenderTarget* target);
-	void render(sf::RenderTarget* target = NULL);
+	void renderGui(sf::RenderTexture* target);
+	void render(sf::RenderTexture* target);
 
 	// State 이벤트
 	void onActivated() {}

--- a/OpenRPG/States/State.cpp
+++ b/OpenRPG/States/State.cpp
@@ -47,4 +47,4 @@ void State::update() {
 	auto dt = Game::getInstance()->deltaTime();
 	this->updateKeytime(dt);
 }
-void State::render(sf::RenderTarget* target) {}
+void State::render(sf::RenderTexture* target) {}

--- a/OpenRPG/States/State.h
+++ b/OpenRPG/States/State.h
@@ -42,7 +42,7 @@ class State {
 	virtual void updateMousePositions();
 
 	virtual void update();
-	virtual void render(sf::RenderTarget* target = NULL);
+	virtual void render(sf::RenderTexture* target);
 
   protected:
 	State* parent;

--- a/OpenRPG/Tiles/Tile.cpp
+++ b/OpenRPG/Tiles/Tile.cpp
@@ -2,14 +2,14 @@
 
 #include "Tile.h"
 
-Tile::Tile(float x, float y, float gridSizeF,const sf::Texture& texture, const sf::IntRect& texture_rect)
+Tile::Tile(float x, float y, float gridSizeF,const g::safe<sf::Texture> texture, const sf::IntRect texture_rect)
 {
 	this->shap.setSize(sf::Vector2f(gridSizeF, gridSizeF));
 	this->shap.setFillColor(sf::Color::White);
 	//this->shap.setOutlineThickness(1.f);
 	//this->shap.setOutlineColor(sf::Color::Black);
 	this->shap.setPosition(x, y);
-	this->shap.setTexture(&texture);
+	this->shap.setTexture(texture.get());
 	this->shap.setTextureRect(texture_rect);
 }
 Tile::~Tile() {}

--- a/OpenRPG/Tiles/Tile.h
+++ b/OpenRPG/Tiles/Tile.h
@@ -6,7 +6,7 @@ class Tile {
 	sf::RectangleShape shap;
 
 public:
-	Tile(float x, float y, float gridSizeF,const sf::Texture& texture, const sf::IntRect& texture_rect);
+	Tile(float x, float y, float gridSizeF,const g::safe<sf::Texture> texture, const sf::IntRect texture_rect);
 	virtual ~Tile();
 
 	void update();


### PR DESCRIPTION
이 브랜치는 <**_43 이슈 (📃 State 업데이트, 렌더링 순서 문제) 수정 #44**>를 수정한 후의 브랜치를 확장해서 작업되었으므로,
이 풀 리퀘스트보다 해당 풀 리퀘스트를 먼저 병합하시기 바랍니다.

### 변경 내용
- 모든 `State`의 `render` 메서드의 인자를 `sf::RenderTexture*`로 변경했습니다.
  * `target` 인자는 이제 `NULL`이 될 수 없습니다.
  * 이제 `State`의 `render` 메서드 내에서 현재까지 그려진 화면 정보를 가져올 수 있습니다. 다음과 같이 가져올 수 있습니다.
  * ```c++
    void State::render(sf::RenderTexture *target) {
        auto backTexture = target->getTexture();
        ...
    }
    ```
- `StateManager`의 `update` 메서드를 수정했습니다.
  * 매 `update`마다 `Game`의 해상도를 가져와 백 텍스쳐를 생성합니다.
  * 생성된 백 텍스쳐는 각 `State`의 `render` 메서드를 호출할 때 전달됩니다.
  * 최상위에 있는 `State`를 그리는 것으로 모든 `State`의 그리기를 끝내고 난 후, 실제로 화면에 그리기를 수행합니다.
  * 기존 코드에서는 각 `State`에서 `NULL` 여부를 검사하여 `target = Game::getWindow().get();`와 같은 코드를 작성해야 했던 문제가 사라졌습니다.